### PR TITLE
Fix recursion bug in ErrorResult

### DIFF
--- a/src/main/java/com/ohmyraid/common/result/ErrorResult.java
+++ b/src/main/java/com/ohmyraid/common/result/ErrorResult.java
@@ -44,7 +44,8 @@ public enum ErrorResult implements Result {
 
     @Override
     public Result setMsgArgs(String resultMsgArgs) {
-        return this.setMsgArgs(resultMsgArgs);
+        this.resultMsgArgs = new String[] { resultMsgArgs };
+        return this;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- correct `setMsgArgs(String)` in `ErrorResult` to avoid recursion

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*